### PR TITLE
Fix broken HTML on Google Site Kit admin screens

### DIFF
--- a/assets/js/organize-admin-notices.js
+++ b/assets/js/organize-admin-notices.js
@@ -1,5 +1,27 @@
 ;( function( $ ) {
+	'use strict';
+
 	var $noticesWrapper;
+
+	/**
+	 * Wrapps all elements found between the opening and closing elements. Aborts
+	 * if the opening and/or closing elements are not found.
+	 *
+	 * @param {string} wrapperClass
+	 */
+	function renderNoticesWrapper( wrapperClass ) {
+		var $open  = $( '#organize-admin-notices--open' );
+		var $close = $( '#organize-admin-notices--close' );
+
+		if ( ! $open.length || ! $close.length ) {
+			return;
+		}
+
+		$open.nextUntil( $close ).wrapAll( '<div class="' + wrapperClass + '" />' );
+
+		$open.remove();
+		$close.remove();
+	}
 
 	function repositionNotices() {
 		var notices = $( 'div.updated, div.error, div.notice' ).not( '.inline, .below-h2' );
@@ -26,7 +48,15 @@
 	}
 
 	function init() {
-		$noticesWrapper = $( '.organize-admin-notices' );
+		var wrapperClass = 'organize-admin-notices';
+
+		renderNoticesWrapper( wrapperClass );
+
+		$noticesWrapper = $( '.' + wrapperClass );
+
+		if ( ! $noticesWrapper.length ) {
+			return;
+		}
 
 		repositionNotices();
 		maybeRenderNoticesToggle();

--- a/organize-admin-notices.php
+++ b/organize-admin-notices.php
@@ -11,7 +11,7 @@
  * Plugin Name: Organize Admin Notices
  * Plugin URI:  https://github.com/timothyjensen/organize-admin-notices
  * Description: Organizes admin notices for a cleaner administrative experience.
- * Version:     0.1.1
+ * Version:     0.1.2
  * Author:      Tim Jensen
  * Author URI:  https://www.timjensen.us
  * Text Domain: organize-admin-notices
@@ -40,30 +40,30 @@ function enqueue_assets() {
 		'organize-admin-notices-css',
 		plugins_url( 'assets/css/style.css', ORGANIZE_ADMIN_NOTICES ),
 		[],
-		'0.1.1'
+		'0.1.2'
 	);
 
 	wp_enqueue_script(
 		'organize-admin-notices',
 		plugins_url( 'assets/js/organize-admin-notices.js', ORGANIZE_ADMIN_NOTICES ),
 		[ 'jquery', 'common' ],
-		'0.1.1',
+		'0.1.2',
 		true
 	);
 }
 
 add_action( 'admin_notices', __NAMESPACE__ . '\\wrap_notices_open', PHP_INT_MIN );
 /**
- * Renders the opening tag for the notices wrapper.
+ * Renders the start element for the notices wrapper that is injected via JavaScript.
  */
 function wrap_notices_open() {
-	echo '<div class="organize-admin-notices">';
+	echo '<div id="organize-admin-notices--open"></div>';
 }
 
 add_action( 'admin_notices', __NAMESPACE__ . '\\wrap_notices_close', PHP_INT_MAX );
 /**
- * Renders the closing tag for the notices wrapper.
+ * Renders the ending element for the notices wrapper that is injected via JavaScript.
  */
 function wrap_notices_close() {
-	echo '</div>';
+	echo '<div id="organize-admin-notices--close"></div>';
 }


### PR DESCRIPTION
Some plugins, such as Google Site Kit, attempt to remove all admin notices on their settings screens. This breaks the HTML rendered by this plugin and causes the settings screen(s) to become hidden until toggled open. This fix ensures settings screens remain visible.

Fixes #2 