### PR TITLE
Improve notice hiding

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -24,12 +24,14 @@
 	border-radius: 50%;
 	color: #fff;
 	content: attr(data-notice-count);
-	display: inline-block;
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
 	font-size: 0.8em;
-	height: 12px;
-	margin-left: 6px;
-	padding: 2px;
-	width: 12px;
+	height: 1.6em;
+	margin-left: 0.6em;
+	padding: 0.1em;
+	width: 1.6em;
 	line-height: 1;
 	font-weight: bold;
 }

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -17,6 +17,8 @@
 	margin-bottom: 0;
 	padding: 3px 6px 3px 16px;
 	transition: box-shadow 0.1s linear;
+	position: relative;
+	z-index: 2;
 }
 
 .organize-admin-notices__toggle::after {

--- a/assets/js/organize-admin-notices.js
+++ b/assets/js/organize-admin-notices.js
@@ -20,7 +20,7 @@
 			return;
 		}
 
-		$( '#screen-meta-links' ).prepend( '<button type="button" class="button organize-admin-notices__toggle" id="organize-admin-notices__toggle" data-notice-count="' + notices.length + '">Notices</button>' );
+		$( '#screen-meta-links' ).prepend( '<button type="button" class="button organize-admin-notices__toggle" id="organize-admin-notices__toggle" aria-label="Toggle visibility of admin notices" data-notice-count="' + notices.length + '">Notices</button>' );
 
 		$( '#organize-admin-notices__toggle' ).on( 'click', function() {
 			$noticesWrapper.toggleClass( 'active' );

--- a/assets/js/organize-admin-notices.js
+++ b/assets/js/organize-admin-notices.js
@@ -13,7 +13,7 @@
 		var notices = $noticesWrapper.children();
 
 		notices = notices.filter( function( index, notice ) {
-			return ! $( notice ).is( ':empty' );
+			return ! $( notice ).is( ':empty, script' );
 		} );
 
 		if ( ! notices.length ) {

--- a/assets/js/organize-admin-notices.js
+++ b/assets/js/organize-admin-notices.js
@@ -3,26 +3,6 @@
 
 	var $noticesWrapper;
 
-	/**
-	 * Wraps all elements found between the opening and closing elements. Aborts
-	 * if the opening and/or closing elements are not found.
-	 *
-	 * @param {string} wrapperClass
-	 */
-	function renderNoticesWrapper( wrapperClass ) {
-		var $open  = $( '#organize-admin-notices--open' );
-		var $close = $( '#organize-admin-notices--close' );
-
-		if ( ! $open.length || ! $close.length ) {
-			return;
-		}
-
-		$open.nextUntil( $close ).addBack().wrapAll( '<div class="' + wrapperClass + '" />' );
-
-		$open.remove();
-		$close.remove();
-	}
-
 	function repositionNotices() {
 		var notices = $( 'div.updated, div.error, div.notice' ).not( '.inline, .below-h2' );
 
@@ -48,11 +28,7 @@
 	}
 
 	function init() {
-		var wrapperClass = 'organize-admin-notices';
-
-		renderNoticesWrapper( wrapperClass );
-
-		$noticesWrapper = $( '.' + wrapperClass );
+		$noticesWrapper = $( '#organize-admin-notices' );
 
 		if ( ! $noticesWrapper.length ) {
 			return;

--- a/organize-admin-notices.php
+++ b/organize-admin-notices.php
@@ -11,7 +11,7 @@
  * Plugin Name: Organize Admin Notices
  * Plugin URI:  https://github.com/timothyjensen/organize-admin-notices
  * Description: Organizes admin notices for a cleaner administrative experience.
- * Version:     0.1.4
+ * Version:     0.2.0
  * Author:      Tim Jensen
  * Author URI:  https://www.timjensen.us
  * Text Domain: organize-admin-notices
@@ -40,30 +40,38 @@ function enqueue_assets() {
 		'organize-admin-notices-css',
 		plugins_url( 'assets/css/style.css', ORGANIZE_ADMIN_NOTICES ),
 		[],
-		'0.1.2'
+		'0.2.0'
 	);
 
 	wp_enqueue_script(
 		'organize-admin-notices',
 		plugins_url( 'assets/js/organize-admin-notices.js', ORGANIZE_ADMIN_NOTICES ),
 		[ 'jquery', 'common' ],
-		'0.1.2',
+		'0.2.0',
 		true
 	);
 }
 
-add_action( 'admin_notices', __NAMESPACE__ . '\\wrap_notices_open', PHP_INT_MIN );
+add_action( 'network_admin_notices', __NAMESPACE__ . '\\wrap_notices_open', -1440 );
+add_action( 'user_admin_notices', __NAMESPACE__ . '\\wrap_notices_open', -1440 );
+add_action( 'admin_notices', __NAMESPACE__ . '\\wrap_notices_open', -1440 );
 /**
- * Renders the start element for the notices wrapper that is injected via JavaScript.
+ * Renders the start element for the notices wrapper.
  */
 function wrap_notices_open() {
-	echo '<div id="organize-admin-notices--open"></div>';
+	static $has_run = null;
+
+	if ( $has_run ) {
+		return;
+	}
+
+	echo '<div id="organize-admin-notices" class="organize-admin-notices">';
 }
 
-add_action( 'admin_notices', __NAMESPACE__ . '\\wrap_notices_close', PHP_INT_MAX );
+add_action( 'all_admin_notices', __NAMESPACE__ . '\\wrap_notices_close', 1440 );
 /**
- * Renders the ending element for the notices wrapper that is injected via JavaScript.
+ * Renders the ending element for the notices wrapper.
  */
 function wrap_notices_close() {
-	echo '<div id="organize-admin-notices--close"></div>';
+	echo '</div>';
 }


### PR DESCRIPTION
Previously notices that fired on the `network_admin_notices`, `user_admin_notices`, and `all_admin_notices` hooks were not being hidden. Now those notices are hidden as well. 

In doing so, I have reworked the approach for rendering the notices wrapper used for hiding the admin notices. The wrapper is now rendered on the server instead of in the browser, which fixes the FOUC issue (#4).

Fixes #4 